### PR TITLE
Split dev.py into main.py and helper functions

### DIFF
--- a/kindle_highlights/helpers.py
+++ b/kindle_highlights/helpers.py
@@ -328,22 +328,3 @@ def process_kindle_highlights(input_file: str, config_path: str) -> bool:
     except Exception as e:
         print(f"Error processing highlights: {str(e)}")
         return False
-
-
-def main(file):
-    """Main function to process Kindle highlights."""
-    # Simple hardcoded configuration
-    input_file = f"./second_brain_collector/kindle_highlights/{file}.txt"
-    config_file = "./second_brain_collector/config.yaml"
-
-    print(f"Processing highlights from: {input_file}")
-    result = process_kindle_highlights(input_file, config_file)
-
-    if result:
-        print("Highlights were successfully processed!")
-    else:
-        print("Failed to process highlights.")
-
-
-if __name__ == "__main__":
-    main("sensitive")

--- a/kindle_highlights/main.py
+++ b/kindle_highlights/main.py
@@ -1,0 +1,8 @@
+from kindle_highlights.helpers import process_kindle_highlights, main as helpers_main
+
+def main(file):
+    """Main function to process Kindle highlights."""
+    helpers_main(file)
+
+if __name__ == "__main__":
+    main("sensitive")


### PR DESCRIPTION
Split `dev.py` into `main.py` and `helpers.py` to organize the code better.

* **main.py**
  - Import `process_kindle_highlights` and `main` functions from `helpers.py`.
  - Add a main function to call `main` with the appropriate file argument.

* **helpers.py**
  - Move `NotionClient` class from `dev.py` to this file.
  - Move `get_config` function from `dev.py` to this file.
  - Move `extract_quotes_from_file` function from `dev.py` to this file.
  - Move `process_kindle_highlights` function from `dev.py` to this file.

* **dev.py**
  - Delete the file as its content has been split into `main.py` and `helpers.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fabwerk90/second_brain_collector/pull/1?shareId=fb317d83-b5e6-4685-b3a8-6c0ae52b27fd).